### PR TITLE
Add ability to convert MSF modules to abilities

### DIFF
--- a/data/abilities/build-capabilities/bed8f28e-c0ed-463e-9e31-d5607e5473df.yml
+++ b/data/abilities/build-capabilities/bed8f28e-c0ed-463e-9e31-d5607e5473df.yml
@@ -1,0 +1,16 @@
+---
+- id: bed8f28e-c0ed-463e-9e31-d5607e5473df
+  name: Load Metasploit Abilities
+  description: Load Metasploit Abilities
+  tactic: build-capabilities
+  technique:
+    name: Build or acquire exploits
+    attack_id: T1349
+  platforms:
+    darwin,linux:
+      sh:
+        command: |
+          msfconsole -r msf_extract.rc
+        timeout: 1000
+        payloads:
+          - msf_extract.rc

--- a/data/abilities/build-capabilities/bed8f28e-c0ed-463e-9e31-d5607e5473df.yml
+++ b/data/abilities/build-capabilities/bed8f28e-c0ed-463e-9e31-d5607e5473df.yml
@@ -10,7 +10,7 @@
     darwin,linux:
       sh:
         command: |
-          msfconsole -r msf_extract.rc
+          msfconsole -r msf_extract.rc #{app.contact.http} #{app.api_key.red}
         timeout: 1000
         payloads:
           - msf_extract.rc

--- a/data/payload/90ef8eaa-01b7-4e98-9070-105eca3bac39.yml
+++ b/data/payload/90ef8eaa-01b7-4e98-9070-105eca3bac39.yml
@@ -1,0 +1,9 @@
+
+---
+
+id: 90ef8eaa-01b7-4e98-9070-105eca3bac39
+name: Access Payloads
+standard_payloads:
+  msf_extract.py:
+    description: GET METASPLOIT EXPLOITS
+    id: 169b74a7-e31b-4dd6-b6ff-721f3a615cc7

--- a/data/payloads/msf_extract.rc
+++ b/data/payloads/msf_extract.rc
@@ -1,0 +1,99 @@
+<ruby>
+
+require 'json'
+require 'net/http'
+require 'securerandom'
+require 'uri'
+
+C2_URI = 'http://0.0.0.0:8888'
+C2_KEY = 'ADMIN123'
+
+def get_exploit_info(exploit_name)
+    exploit = self.framework.modules.create(exploit_name)
+    privileged = exploit.privileged ? "Elevated" : ""
+    platforms = exploit.target_platform.platforms.map {|plat| plat.realname }
+
+    params = []
+    for name, option in exploit.options
+        unless option.advanced || name.starts_with?("HTTP::")
+            params.push(name)
+        end
+    end
+
+    data = {
+        "name" => exploit.name,
+        "description" => exploit.description.nil? ? "metasploit exploit" : exploit.description,
+        "platform" => platforms,
+        "privilege" => exploit.privileged ? "Elevated" : "",
+        "module" => exploit.realname,
+        "params" => params
+    }
+end
+
+def convert_to_ability(exploit)
+    command = 'msfconsole -x "use ' + exploit['module'] + '; '
+    for param in exploit['params']
+        command += 'set ' + param + ' ' + '#{msf.' + param + '}; '
+    end
+    command += 'run"'
+
+    os = get_os
+    executor = (os == "windows" ? "cmd" : "sh")
+
+    ability = {
+        "id" => SecureRandom.uuid,
+        "tactic" => "metasploit",
+        "technique" => {
+            "name" => "metasploit",
+            "attack_id" => "MSF999"
+        },
+        "name" => exploit['name'],
+        "description" => exploit['description'],
+        "privilege" => exploit['privilege'],
+        "platforms" => {
+            os => {
+                executor => {
+                    "command" => command,
+                    "timeout" => 600,
+                }
+            }
+        }
+    }
+    ability['unique'] = ability['id']
+    return ability
+end
+
+def get_os
+    if (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM) != nil
+        return "windows"
+    elsif (/darwin/ =~ RUBY_PLATFORM) != nil
+        return "darwin"
+    else
+        return "linux"
+    end
+end
+
+def save_ability(ability)
+    uri = URI.parse(C2_URI + '/api/rest')
+    header = {
+        'Content-Type' => 'text/json',
+        'KEY' => C2_KEY
+    }
+    http = Net::HTTP.new(uri.host, uri.port)
+    request = Net::HTTP::Put.new(uri.request_uri, header)
+    ability['index'] = 'abilities'
+    request.body = ability.to_json
+    response = http.request(request)
+end
+
+for exploit_name in self.framework.exploits.keys
+    exploit = get_exploit_info(exploit_name)
+    ability = convert_to_ability(exploit)
+    response = save_ability(ability)
+end
+
+exit(true)
+
+</ruby>
+
+quit

--- a/data/payloads/msf_extract.rc
+++ b/data/payloads/msf_extract.rc
@@ -5,9 +5,6 @@ require 'net/http'
 require 'securerandom'
 require 'uri'
 
-C2_URI = 'http://0.0.0.0:8888'
-C2_KEY = 'ADMIN123'
-
 def get_exploit_info(exploit_name)
     exploit = self.framework.modules.create(exploit_name)
     privileged = exploit.privileged ? "Elevated" : ""
@@ -73,11 +70,11 @@ def get_os
     end
 end
 
-def save_ability(ability)
-    uri = URI.parse(C2_URI + '/api/rest')
+def save_ability(ability, c2_uri, c2_key)
+    uri = URI.parse(c2_uri + '/api/rest')
     header = {
         'Content-Type' => 'text/json',
-        'KEY' => C2_KEY
+        'KEY' => c2_key
     }
     http = Net::HTTP.new(uri.host, uri.port)
     request = Net::HTTP::Put.new(uri.request_uri, header)
@@ -86,10 +83,13 @@ def save_ability(ability)
     response = http.request(request)
 end
 
+c2_uri = ARGV.shift || 'http://0.0.0.0:8888'
+c2_key = ARGV.shift || 'ADMIN123'
+
 for exploit_name in self.framework.exploits.keys
     exploit = get_exploit_info(exploit_name)
     ability = convert_to_ability(exploit)
-    response = save_ability(ability)
+    response = save_ability(ability, c2_uri, c2_key)
 end
 
 exit(true)


### PR DESCRIPTION
Re-used ability from #17 but gave it a tactic/technique from Pre-ATT&CK.

Open Question: The previous pull request used the platform the script ran on as the platform given to the abilities: https://github.com/mitre/access/pull/17/files#diff-2f7ad5c1a5f3e50522d0d4b207953d5dR135 I replicated that here, but it would be more accurate to try to parse the platform from the metasploit module instead.

`app.contact.http` in config must include `http://` and `app.api_key.red` must be added to fact source.