### PR TITLE
Missing executor bug

### DIFF
--- a/app/access_api.py
+++ b/app/access_api.py
@@ -47,7 +47,9 @@ class AccessApi:
         ability_search = dict(access=tuple(await self.auth_svc.get_permissions(request)), ability_id=data['ability_id'])
         ability = (await self.data_svc.locate('abilities', match=ability_search))[0]
         executor = await agent.get_preferred_executor(ability)
+        if not executor:
+            return web.json_response(dict(error='Executor not found for ability'))
         trimmed_ability = copy.deepcopy(ability)
         trimmed_ability.remove_all_executors()
-        trimmed_ability.add_executor(executor)
+        trimmed_ability.add_executor(executor) 
         return web.json_response(trimmed_ability.display)

--- a/app/access_api.py
+++ b/app/access_api.py
@@ -51,5 +51,5 @@ class AccessApi:
             return web.json_response(dict(error='Executor not found for ability'))
         trimmed_ability = copy.deepcopy(ability)
         trimmed_ability.remove_all_executors()
-        trimmed_ability.add_executor(executor) 
+        trimmed_ability.add_executor(executor)
         return web.json_response(trimmed_ability.display)

--- a/templates/access.html
+++ b/templates/access.html
@@ -141,6 +141,10 @@
 
     function setProperties() {
         function propertiesCallback(ability) {
+            if ('error' in ability){
+                stream(ability.error)
+                return;
+            } 
             let found = [], rxp = /#{([^}]+)}/g, str = ability.executors[0].command, curMatch;
             while(curMatch = rxp.exec(str)) {
                 found.push(curMatch[1]);


### PR DESCRIPTION
## Description

If the ability chosen in the access plugin does not have an executor when the 'Populate Variables' button is selected, a 500 error occurs with no helpful message. This change catches that case, and provides useful message to user, instead of internal server error.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Manually through the UI.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
