### PR TITLE
Update metasploit load ability to work with v2 api

### DIFF
--- a/data/abilities/build-capabilities/bed8f28e-c0ed-463e-9e31-d5607e5473df.yml
+++ b/data/abilities/build-capabilities/bed8f28e-c0ed-463e-9e31-d5607e5473df.yml
@@ -10,7 +10,7 @@
     darwin,linux:
       sh:
         command: |
-          msfconsole -r msf_extract.rc #{app.contact.http} #{app.api_key.red}
+          msfconsole -r msf_extract.rb #{app.contact.http} #{app.api_key.red}
         timeout: 1000
         payloads:
-          - msf_extract.rc
+          - msf_extract.rb

--- a/data/payloads/msf_extract.rb
+++ b/data/payloads/msf_extract.rb
@@ -57,25 +57,19 @@ def convert_to_ability(exploit)
     executor = (os == "windows" ? "cmd" : "sh")
 
     ability = {
-        "id" => SecureRandom.uuid,
+        "ability_id" => SecureRandom.uuid,
         "tactic" => "metasploit",
-        "technique" => {
-            "name" => "metasploit",
-            "attack_id" => "MSF999"
-        },
+        "technique_name" => "metasploit",
+        "technique_id" => "T1349",
         "name" => exploit['name'],
         "description" => exploit['description'],
         "privilege" => exploit['privilege'],
-        "platforms" => {
-            os => {
-                executor => {
-                    "command" => command,
-                    "timeout" => 600,
-                }
-            }
-        }
+        "executors" => [{
+            "command" => command,
+            "timeout" => 60,
+            "platform" => os
+        }]
     }
-    ability['unique'] = ability['id']
     return ability
 end
 
@@ -90,14 +84,13 @@ def get_os
 end
 
 def save_ability(ability, c2_uri, c2_key)
-    uri = URI.parse(c2_uri + '/api/rest')
+    uri = URI.parse(c2_uri + '/api/v2/abilities')
     header = {
         'Content-Type' => 'text/json',
         'KEY' => c2_key
     }
     http = Net::HTTP.new(uri.host, uri.port)
-    request = Net::HTTP::Put.new(uri.request_uri, header)
-    ability['index'] = 'abilities'
+    request = Net::HTTP::Post.new(uri, header)
     request.body = ability.to_json
     response = http.request(request)
 end


### PR DESCRIPTION
## Description

This pull request updates the `msf_extract.rc` payload to work with the new Caldera API.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I ran the ability on my local machine, and it was able to successfully import from metasploit.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
