### PR TITLE
Fix Copilot code review feedback in test suite

### DIFF
--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -2,16 +2,16 @@
 
 Tests cover:
 - hook.py syntax validation via ast.parse
-- Abilities YAML validation (if present)
-- Requirements.txt dependency checks (if present)
+- Abilities YAML validation
 - Security pattern scanning across Python source files
 """
 import ast
 import os
 import glob
-import re
 
 import pytest
+
+yaml = pytest.importorskip("yaml")
 
 PLUGIN_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -22,7 +22,7 @@ class TestHookSyntax:
     def test_hook_parses(self):
         """hook.py should be valid Python syntax."""
         hook_path = os.path.join(PLUGIN_DIR, "hook.py")
-        with open(hook_path, "r") as fh:
+        with open(hook_path, encoding='utf-8') as fh:
             source = fh.read()
         tree = ast.parse(source, filename="hook.py")
         assert isinstance(tree, ast.Module)
@@ -30,7 +30,7 @@ class TestHookSyntax:
     def test_hook_has_no_bare_exec(self):
         """hook.py should not contain bare exec() calls."""
         hook_path = os.path.join(PLUGIN_DIR, "hook.py")
-        with open(hook_path, "r") as fh:
+        with open(hook_path, encoding='utf-8') as fh:
             source = fh.read()
         tree = ast.parse(source)
         for node in ast.walk(tree):
@@ -47,7 +47,7 @@ class TestHookSyntax:
                 if not fname.endswith(".py"):
                     continue
                 fpath = os.path.join(root, fname)
-                with open(fpath, "r") as fh:
+                with open(fpath, encoding='utf-8') as fh:
                     source = fh.read()
                 try:
                     ast.parse(source, filename=fname)
@@ -74,20 +74,18 @@ class TestAbilitiesYaml:
 
     def test_abilities_yaml_parseable(self):
         """Each abilities YAML file should be parseable."""
-        import yaml
         for yf in self._yaml_files():
-            with open(yf, "r") as fh:
+            with open(yf, encoding='utf-8') as fh:
                 try:
-                    docs = list(yaml.safe_load_all(fh))
+                    list(yaml.safe_load_all(fh))
                 except yaml.YAMLError as exc:
                     rel = os.path.relpath(yf, PLUGIN_DIR)
                     pytest.fail(f"YAML parse error in {rel}: {exc}")
 
     def test_abilities_have_required_fields(self):
         """Each ability must have id, name, and tactic fields."""
-        import yaml
         for yf in self._yaml_files():
-            with open(yf, "r") as fh:
+            with open(yf, encoding='utf-8') as fh:
                 docs = list(yaml.safe_load_all(fh))
             for doc in docs:
                 if doc is None:
@@ -103,10 +101,9 @@ class TestAbilitiesYaml:
 
     def test_abilities_ids_are_unique(self):
         """Ability IDs should not be duplicated within the plugin."""
-        import yaml
         seen = {}
         for yf in self._yaml_files():
-            with open(yf, "r") as fh:
+            with open(yf, encoding='utf-8') as fh:
                 docs = list(yaml.safe_load_all(fh))
             for doc in docs:
                 if doc is None:
@@ -138,13 +135,17 @@ class TestSecurityPatterns:
     def test_no_verify_false(self):
         """No Python file should use verify=False (disables TLS verification)."""
         for fpath in self._py_files():
-            with open(fpath, "r") as fh:
-                for lineno, line in enumerate(fh, 1):
-                    if "verify=False" in line and not line.strip().startswith("#"):
-                        rel = os.path.relpath(fpath, PLUGIN_DIR)
-                        pytest.fail(
-                            f"verify=False found at {rel}:{lineno}"
-                        )
+            with open(fpath, encoding='utf-8') as fh:
+                source = fh.read()
+            tree = ast.parse(source)
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Call):
+                    for kw in node.keywords:
+                        if kw.arg == 'verify' and isinstance(kw.value, ast.Constant) and kw.value.value is False:
+                            rel = os.path.relpath(fpath, PLUGIN_DIR)
+                            pytest.fail(
+                                f"verify=False found at {rel}:{node.lineno}"
+                            )
 
     def test_no_unguarded_shell_true(self):
         """No Python file should use shell=True outside of known-safe patterns."""
@@ -153,40 +154,36 @@ class TestSecurityPatterns:
             fname = os.path.basename(fpath)
             if any(fname.startswith(a) or fname == a for a in allowlist):
                 continue
-            with open(fpath, "r") as fh:
-                for lineno, line in enumerate(fh, 1):
-                    stripped = line.strip()
-                    if stripped.startswith("#"):
-                        continue
-                    if "shell=True" in stripped:
-                        rel = os.path.relpath(fpath, PLUGIN_DIR)
-                        pytest.fail(
-                            f"shell=True found at {rel}:{lineno}"
-                        )
+            with open(fpath, encoding='utf-8') as fh:
+                source = fh.read()
+            tree = ast.parse(source)
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Call):
+                    for kw in node.keywords:
+                        if kw.arg == 'shell' and isinstance(kw.value, ast.Constant) and kw.value.value is True:
+                            rel = os.path.relpath(fpath, PLUGIN_DIR)
+                            pytest.fail(
+                                f"shell=True found at {rel}:{node.lineno}"
+                            )
 
     def test_requests_have_timeout(self):
         """requests.get/post/put/delete calls should include a timeout parameter."""
-        pattern = re.compile(r"requests\.(get|post|put|delete|patch|head)\(")
+        requests_methods = {'get', 'post', 'put', 'delete', 'patch', 'head'}
         for fpath in self._py_files():
-            with open(fpath, "r") as fh:
+            with open(fpath, encoding='utf-8') as fh:
                 source = fh.read()
-            for match in pattern.finditer(source):
-                start = match.start()
-                depth = 0
-                end = start
-                for i in range(start, min(start + 500, len(source))):
-                    if source[i] == "(":
-                        depth += 1
-                    elif source[i] == ")":
-                        depth -= 1
-                        if depth == 0:
-                            end = i
-                            break
-                call_text = source[start:end]
-                if "timeout" not in call_text:
-                    line_num = source[:start].count("\n") + 1
-                    rel = os.path.relpath(fpath, PLUGIN_DIR)
-                    pytest.fail(
-                        f"requests call without timeout at {rel}:{line_num}"
-                    )
-
+            tree = ast.parse(source)
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Call):
+                    func = node.func
+                    is_requests_call = False
+                    if isinstance(func, ast.Attribute) and func.attr in requests_methods:
+                        if isinstance(func.value, ast.Name) and func.value.id == 'requests':
+                            is_requests_call = True
+                    if is_requests_call:
+                        keyword_names = [kw.arg for kw in node.keywords if kw.arg is not None]
+                        if 'timeout' not in keyword_names:
+                            rel = os.path.relpath(fpath, PLUGIN_DIR)
+                            pytest.fail(
+                                f"requests call without timeout at {rel}:{node.lineno}"
+                            )


### PR DESCRIPTION
## Summary
- Use pytest.importorskip("yaml") instead of bare import
- Add encoding='utf-8' to all open() calls
- Replace regex-based security scanning with AST-based approach
- Remove unused re import
- Update docstring to match actual test coverage

## Test plan
- [x] All 11 existing tests pass